### PR TITLE
Add top border to card header if the header isnt the first child

### DIFF
--- a/scss/_card.scss
+++ b/scss/_card.scss
@@ -71,6 +71,10 @@
   background-color: $card-cap-bg;
   border-bottom: $card-border-width solid $card-border-color;
 
+  &:not(:first-child) {
+    border-top: $card-border-width solid $card-border-color;
+  }
+
   &:first-child {
     @include border-radius($card-border-radius-inner $card-border-radius-inner 0 0);
   }


### PR DESCRIPTION
This allows a card to have multiple headers.

I chose to do this rather than add a sub-header class.
